### PR TITLE
fix files having no content

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	ps := plugin.NewSet()
 	ps.RegisterProvisioner(plugin.DEFAULT_NAME, &S3Provisioner{})
-	ps.SetVersion(version.NewPluginVersion("2.0.1", "", ""))
+	ps.SetVersion(version.NewPluginVersion("2.0.2", "", ""))
 	err := ps.Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/provisioner.go
+++ b/provisioner.go
@@ -109,15 +109,13 @@ func (p *S3Provisioner) Provision(
 		}
 
 		var (
-			parts  = strings.Split(src, "/")
-			bucket = parts[0]
-			path   = strings.Join(parts[1:], "/")
+			parts   = strings.Split(src, "/")
+			bucket  = parts[0]
+			path    = strings.Join(parts[1:], "/")
+			writeAt = manager.NewWriteAtBuffer(make([]byte, 0))
 		)
 
 		ui.Sayf("retrieving object %s from bucket %s", path, bucket)
-
-		buf := make([]byte, 0)
-		writeAt := manager.NewWriteAtBuffer(buf)
 
 		if _, err := downloader.Download(ctx, writeAt, &s3.GetObjectInput{
 			Bucket: &bucket,
@@ -126,7 +124,7 @@ func (p *S3Provisioner) Provision(
 			return fmt.Errorf("error downloading object %s: %v", path, err)
 		}
 
-		if err := communicator.Upload(dest, bytes.NewReader(buf), nil); err != nil {
+		if err := communicator.Upload(dest, bytes.NewReader(writeAt.Bytes()), nil); err != nil {
 			return fmt.Errorf("error uploading object %s: %v", path, err)
 		}
 	}

--- a/provisioner_acc_test.go
+++ b/provisioner_acc_test.go
@@ -4,14 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/hashicorp/packer-plugin-sdk/acctest"
 	"os"
 	"os/exec"
 	"testing"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/hashicorp/packer-plugin-sdk/acctest"
-
 	"github.com/freggy/packers3/testdata"
 )
 
@@ -20,6 +19,7 @@ func TestAccS3Basic(t *testing.T) {
 		ctx     = context.Background()
 		bucket  = "s3-acc-test"
 		objName = "dir/file1"
+		content = "this-is-file-content"
 	)
 
 	cfg, err := awsconfig.LoadDefaultConfig(
@@ -36,8 +36,11 @@ func TestAccS3Basic(t *testing.T) {
 		{
 			Name:     "s3_profile_basic_test",
 			Template: testdata.ProfileTemplate,
+			BuildExtraArgs: []string{
+				fmt.Sprintf("-var=expected_content=%s", content),
+			},
 			Setup: func() error {
-				if err := setupBucket(ctx, client, bucket, objName); err != nil {
+				if err := setupBucket(ctx, client, bucket, objName, content); err != nil {
 					return err
 				}
 				return os.Setenv("AWS_CONFIG_FILE", "testdata/aws_config")
@@ -50,8 +53,11 @@ func TestAccS3Basic(t *testing.T) {
 		{
 			Name:     "s3_env_basic_test",
 			Template: testdata.EnvTemplate,
+			BuildExtraArgs: []string{
+				fmt.Sprintf("-var=expected_content=%s", content),
+			},
 			Setup: func() error {
-				if err := setupBucket(ctx, client, bucket, objName); err != nil {
+				if err := setupBucket(ctx, client, bucket, objName, content); err != nil {
 					return err
 				}
 				if err = os.Setenv("AWS_ACCESS_KEY_ID", envOrDie(t, "S3_ACC_TEST_ACCESS_KEY")); err != nil {
@@ -80,7 +86,7 @@ func TestAccS3Basic(t *testing.T) {
 	}
 }
 
-func setupBucket(ctx context.Context, client *s3.Client, bucket, obj string) error {
+func setupBucket(ctx context.Context, client *s3.Client, bucket, obj, content string) error {
 	if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
 		Bucket: &bucket,
 	}); err != nil {
@@ -90,7 +96,7 @@ func setupBucket(ctx context.Context, client *s3.Client, bucket, obj string) err
 	if _, err := client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: &bucket,
 		Key:    &obj,
-		Body:   bytes.NewReader([]byte(testdata.ProfileTemplate)),
+		Body:   bytes.NewReader([]byte(content)),
 	}); err != nil {
 		return fmt.Errorf("failed to put object: %v", err)
 	}

--- a/provisioner_acc_test.go
+++ b/provisioner_acc_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/hashicorp/packer-plugin-sdk/acctest"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/acctest"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"

--- a/testdata/env.pkr.hcl
+++ b/testdata/env.pkr.hcl
@@ -7,6 +7,10 @@ packer {
   }
 }
 
+variable "expected_content" {
+  type = string
+}
+
 source "docker" "test" {
   image = "alpine"
   commit = "true"
@@ -27,5 +31,12 @@ build {
       source      = "s3-acc-test/dir/file1"
       destination = "/tmp/file2"
     }
+  }
+
+  provisioner "shell" {
+    inline = [
+      "[[ $(cat /tmp/file1) == ${var.expected_content} ]] && exit 0 || exit 1",
+      "[[ $(cat /tmp/file2) == ${var.expected_content} ]] && exit 0 || exit 1",
+    ]
   }
 }

--- a/testdata/profile.pkr.hcl
+++ b/testdata/profile.pkr.hcl
@@ -7,6 +7,10 @@ packer {
   }
 }
 
+variable "expected_content" {
+  type = string
+}
+
 source "docker" "test" {
   image = "alpine"
   commit = "true"
@@ -28,5 +32,12 @@ build {
       source      = "s3-acc-test/dir/file1"
       destination = "/tmp/file2"
     }
+  }
+
+  provisioner "shell" {
+    inline = [
+      "[[ $(cat /tmp/file1) == ${var.expected_content} ]] && exit 0 || exit 1",
+      "[[ $(cat /tmp/file2) == ${var.expected_content} ]] && exit 0 || exit 1",
+    ]
   }
 }


### PR DESCRIPTION
it appears that the byte arry passed to `writerAt` will not contain the downloaded object content.
passing `writerAt.Bytes()` solves this issue.

also ensure the files content is what we expect.

fixes #6